### PR TITLE
SignatureHelper breaking on TArray fix

### DIFF
--- a/Source/AndroidNative/Public/Helpers/SignatureHelper.h
+++ b/Source/AndroidNative/Public/Helpers/SignatureHelper.h
@@ -1,4 +1,4 @@
-﻿// Georgy Treshchev 2024.
+// Georgy Treshchev 2024.
 
 #pragma once
 
@@ -74,8 +74,12 @@ namespace SignatureHelper
 
 	/** Get the signature for the type contained in TArray */
 	template <typename PassedType>
-	static FORCEINLINE typename TEnableIf<TIsTArray<PassedType>::Value, const ANSICHAR*>::Type
-	GetTypeSignature() { return const_cast<ANSICHAR*>(StringCast<ANSICHAR>(*FString::Printf(TEXT("[%s"), *FString(GetTypeSignature<typename PassedType::ElementType>()))).Get()); }
+	static FORCEINLINE typename TEnableIf<TIsTArray<PassedType>::Value, FString>::Type
+	GetTypeSignature()
+	{
+		// Build and return a stable FString (e.g., "[I" for TArray<int32>)
+		return FString::Printf(TEXT("[%s"), *FString(GetTypeSignature<typename PassedType::ElementType>()));
+	}
 
 	/**
 	 * In case no arguments and type are specified


### PR DESCRIPTION
0>SignatureHelper.h(78,52): Error  : returning address of local temporary object [-Werror,-Wreturn-stack-address]
0>   78 |         GetTypeSignature() { return const_cast<ANSICHAR>(StringCast<ANSICHAR>(FString::Printf(TEXT("[%s"), *FString(GetTypeSignature<typename PassedType::ElementType>()))).Get()); }
0>
AI Assistant
Diagnosis
The error returning address of local temporary object [-Werror,-Wreturn-stack-address] is triggered by the TArray specialization of SignatureHelper::GetTypeSignature. It constructs an FString and then uses StringCast(...).Get() to obtain a pointer to a transient buffer owned by a temporary StringCast. That buffer becomes invalid as soon as the expression ends, so returning it yields a dangling pointer.
This hits when you call CallJavaStaticMethod<TArray>(...), since it needs the JNI signature for an int32 array, which should be "[I". The faulty specialization tries to build and return that via a temporary cast.
Fix
Make the TArray specialization return an owning FString instead of a pointer, and build the signature directly as a TCHAR string. This avoids returning a pointer to a temporary. All concatenations are done into an FString already, so appending a FString works seamlessly.

Why this resolves the error
- No pointer to data owned by a temporary is returned anymore.
- For TArray, this now correctly produces the JNI type signature "[I" as an FString, which is safely appended in GetTypeSignatures and GetMethodSignature.

Notes
- Other GetTypeSignature overloads return string literals (which have static storage duration), so they are safe.
- At the final call site, you already convert the complete method signature FString to ANSICHAR just-in-time, which is safe within that expression.